### PR TITLE
fix: disable SSL rejection for unsigned connections

### DIFF
--- a/server/db/postgres.js
+++ b/server/db/postgres.js
@@ -12,7 +12,11 @@ export class Postgres {
 
   static async createConnection(conn_str) {
     const instance = new Postgres();
-    await instance.#init({ connectionString: conn_str });
+    await instance.#init({
+      connectionString: conn_str,
+      ssl: { rejectUnauthorized: false },
+    });
+
     return instance;
   }
 


### PR DESCRIPTION
## Description

[node-postgres](https://github.com/brianc/node-postgres) uses the default `sslmode` in `libpq` which is `prefer`

This creates the following issue in some postgres connections:

```
FATAL: no pg_hba.conf entry for host "ip-addres", user "my-user", database "my-db", no encryption
```

**Context:**

https://github.com/brianc/node-postgres/issues/2720

## Proposed fix.

adding `ssl: { rejectUnauthorized: false }` which bypasses SSL requirements